### PR TITLE
Prevent voter additions after first voting round starts

### DIFF
--- a/voting/forms.py
+++ b/voting/forms.py
@@ -101,6 +101,10 @@ class VotingVoterAddForm(InvalidFormMixin, Form):
             and VotingVoter.objects.filter(voting=self.voting, voter__member_id=member_id).exists()
         ):
             raise ValidationError("Dieses Mitglied nimmt bereits an dieser Bieterrunde teil.")
+        if self.voting and self.voting.rounds_started:
+            raise ValidationError(
+                "Teilnehmer können nicht hinzugefügt werden, nachdem die erste Runde begonnen hat."
+            )
         return member_id
 
     def get_bids(self):
@@ -155,6 +159,11 @@ class VotingVoterQuickAddForm(InvalidFormMixin, Form):
             if already:
                 raise ValidationError(
                     f"Bereits teilnehmend: {', '.join(str(m) for m in sorted(already))}"
+                )
+            if self.voting.rounds_started:
+                raise ValidationError(
+                    "Teilnehmer können nicht hinzugefügt werden, "
+                    "nachdem die erste Runde begonnen hat."
                 )
         return member_ids
 

--- a/voting/models.py
+++ b/voting/models.py
@@ -106,6 +106,10 @@ class Voting(models.Model):
     def has_voters(self) -> bool:
         return self.voters.exists()
 
+    @property
+    def rounds_started(self) -> bool:
+        return self.rounds.exists()
+
     def new_round(self) -> "VotingRound":
         if self.voter_count == 0:
             raise ValueError("Keine Teilnehmer vorhanden")
@@ -126,6 +130,10 @@ class Voting(models.Model):
 
     @atomic
     def import_bids_csv(self, csv_lines: list[str]):
+        if self.rounds_started:
+            raise ValueError(
+                "Gebote können nicht importiert werden, nachdem die erste Runde begonnen hat."
+            )
         for row in csv.reader(csv_lines, delimiter=";" if ";" in csv_lines[0] else ","):
             if not row or not row[0].isdigit():
                 # Skip empty lines, headers and/or comments
@@ -165,6 +173,12 @@ class VotingVoter(models.Model):
 
     def __str__(self):
         return f"{self.voter} @ {self.voting}"
+
+    def clean(self):
+        if self._state.adding and self.voting_id and self.voting.rounds_started:
+            raise ValidationError(
+                "Teilnehmer können nicht hinzugefügt werden, nachdem die erste Runde begonnen hat."
+            )
 
     def is_absent_for_round(self, round_number: int) -> bool:
         return self.absent_from_round is not None and self.absent_from_round <= round_number

--- a/voting/templates/voting/htmx/manage_voters.html
+++ b/voting/templates/voting/htmx/manage_voters.html
@@ -41,6 +41,7 @@
         {% else %}
         <p>Keine Teilnehmer vorhanden.</p>
         {% endif %}
+        {% if not voting.rounds_started %}
         <div role="group" hx-boost="true">
             <a role="button" class="pico-background-green"
                href="{% url "voting:voter-add" voting_id=voting.id %}"
@@ -51,6 +52,9 @@
                hx-target="closest dialog"
                hx-swap="outerHTML">Mehrere Teilnehmer hinzufügen</a>
         </div>
+        {% else %}
+        <p><small>Keine weiteren Teilnehmer können hinzugefügt werden, da die erste Runde bereits begonnen hat.</small></p>
+        {% endif %}
     </article>
     {% endif %}
 </dialog>

--- a/voting/tests.py
+++ b/voting/tests.py
@@ -640,3 +640,102 @@ def test_voter_management_owner_only(client, voting):
     )
     assert response.status_code == 302
     assert response["Location"] == reverse("voting:index")
+
+
+# ---------------------------------------------------------------------------
+# Restrict voter additions once the first round has started
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_voting_rounds_started_property(voting):
+    assert voting.rounds_started is False
+    voting.new_round()
+    assert voting.rounds_started is True
+
+
+@pytest.mark.django_db
+def test_voter_add_blocked_after_round_started(client, owner, voting):
+    client.force_login(owner)
+    voting.new_round()
+    make_voter(999, "Too Late")
+    response = client.post(
+        reverse("voting:voter-add", args=[voting.id]),
+        {"member_id": "999"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 200
+    assert "erste Runde" in response.content.decode()
+    assert not VotingVoter.objects.filter(voting=voting, voter__member_id=999).exists()
+
+
+@pytest.mark.django_db
+def test_voter_quick_add_blocked_after_round_started(client, owner, voting):
+    client.force_login(owner)
+    voting.new_round()
+    make_voter(801, "Too Late A")
+    make_voter(802, "Too Late B")
+    response = client.post(
+        reverse("voting:voter-quick-add", args=[voting.id]),
+        {"member_ids": "801, 802"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 200
+    assert "erste Runde" in response.content.decode()
+    assert not VotingVoter.objects.filter(voting=voting, voter__member_id=801).exists()
+    assert not VotingVoter.objects.filter(voting=voting, voter__member_id=802).exists()
+
+
+@pytest.mark.django_db
+def test_voter_registration_blocked_after_round_started(client, voting):
+    voter = make_voter(310)
+    voting.new_round()
+    token = compute_member_token(310)
+    response = client.get(
+        reverse(
+            "voting:voter-registration",
+            kwargs={"voting_id": voting.id, "member_id": 310, "auth_token": token},
+        )
+    )
+    assert response.status_code == 403
+    assert not VotingVoter.objects.filter(voting=voting, voter=voter).exists()
+
+
+@pytest.mark.django_db
+def test_voter_registration_still_works_for_existing_voter(client, voting):
+    # Voter with member_id=1 is already part of the fixture voting
+    voter = Voter.objects.get(member_id=1)
+    token = compute_member_token(1)
+    voting.new_round()
+    url = reverse(
+        "voting:voter-registration",
+        kwargs={"voting_id": voting.id, "member_id": 1, "auth_token": token},
+    )
+    response = client.post(url, {"attending": "on", "bid_round_1": "42"})
+    assert response.status_code == 302
+    vv = VotingVoter.objects.get(voting=voting, voter=voter)
+    assert vv.absent_from_round is None
+    assert voting.bids.filter(member_id=1, round_number=1).first().amount == Decimal("42")
+
+
+@pytest.mark.django_db
+def test_import_bids_csv_blocked_after_round_started(voting):
+    voting.new_round()
+    with pytest.raises(ValueError, match="erste Runde"):
+        voting.import_bids_csv(["500,1,2"])
+
+
+@pytest.mark.django_db
+def test_voting_voter_model_clean_blocks_after_round_started(voting):
+    voting.new_round()
+    new_voter = make_voter(700, "Late Joiner")
+    vv = VotingVoter(voting=voting, voter=new_voter)
+    with pytest.raises(ValidationError):
+        vv.full_clean()
+
+
+@pytest.mark.django_db
+def test_voting_voter_model_clean_allows_before_round_started(voting):
+    new_voter = make_voter(701, "Early Bird")
+    vv = VotingVoter(voting=voting, voter=new_voter)
+    vv.full_clean()  # must not raise

--- a/voting/views.py
+++ b/voting/views.py
@@ -337,7 +337,14 @@ def voter_registration(request, voting_id, member_id, auth_token):
 
     voting = get_object_or_404(Voting, pk=voting_id)
     voter = get_object_or_404(Voter, member_id=member_id)
-    voting_voter, vv_created = VotingVoter.objects.get_or_create(voting=voting, voter=voter)
+    voting_voter = VotingVoter.objects.filter(voting=voting, voter=voter).first()
+    vv_missing = voting_voter is None
+    if vv_missing:
+        if voting.rounds_started:
+            return HttpResponseForbidden(
+                "Registrierung ist nicht mehr möglich, da die erste Runde bereits begonnen hat."
+            )
+        voting_voter = VotingVoter.objects.create(voting=voting, voter=voter)
 
     if request.method == "POST":
         form = VoterRegistrationForm(request.POST)
@@ -366,7 +373,7 @@ def voter_registration(request, voting_id, member_id, auth_token):
             voting.bids.filter(member_id=member_id).values_list("round_number", "amount")
         )
         initial = {
-            "attending": voting_voter.absent_from_round is None if not vv_created else False
+            "attending": voting_voter.absent_from_round is None if not vv_missing else False
         }
         for round_number, amount in existing_bids.items():
             initial[f"bid_round_{round_number}"] = amount


### PR DESCRIPTION
## Summary
This PR implements restrictions to prevent adding new voters to a voting session once the first round has started. This ensures the voter roster remains stable during active voting.